### PR TITLE
Allow ignoring pending replaces

### DIFF
--- a/findPendingReplacements.ts
+++ b/findPendingReplacements.ts
@@ -4,12 +4,14 @@ import { join } from "path";
 import { PatchContext } from "./config";
 import { DocsReplacements, LineReplacement } from "./patches/docsReplacements";
 import glob from "fast-glob";
+import ignore from "ignore";
 
-export async function findPendingReplacements(ctx: PatchContext) {
+export async function findPendingReplacements(ctx: PatchContext, ignores: string[]) {
   const suggestions: DocsReplacements = {};
   const files = await glob("website/**/*.markdown", { cwd: ctx.dir });
+  const filter = ignore().add(ignores).add(["website/docs/index.html.markdown"]);
   for (const file of files) {
-    if (file === "website/docs/index.html.markdown") {
+    if (filter.ignores(file)) {
       continue;
     }
     const filePath = join(ctx.dir, file);

--- a/patches/docsReplacements.ts
+++ b/patches/docsReplacements.ts
@@ -13,8 +13,8 @@ export async function applyDocsReplacements(
 ) {
   const replacements = await readReplacements(replacementsPath);
   const files = await glob(pathPattern, { cwd: ctx.dir });
+  const fileFilter = ignore().add(ignores);
   for (const file of files) {
-    const fileFilter = ignore().add(ignores);
     // Skip index - we don't use this in docs gen.
     if (fileFilter.ignores(file)) {
       continue;


### PR DESCRIPTION
This allows the `.patche-ignores` file to be used for finding replaces. This is necessary to incorporate `pulumi-aws` `v5.7.0` since we don't want to maintain `cdktf` replaces when they will not be used in our docs.